### PR TITLE
add user-agent

### DIFF
--- a/lib/mtgox/connection.rb
+++ b/lib/mtgox/connection.rb
@@ -8,6 +8,7 @@ module MtGox
       options = {
         :ssl => {:verify => false},
         :url => 'https://mtgox.com',
+        :headers  => {:user_agent => "MtGoxGem"}
       }
 
       Faraday.new(options) do |connection|


### PR DESCRIPTION
add user-agent to each request header, MtGox is blocking requests with empty user agent

use 'MtGoxGem' as the user-agent string
