### PR TITLE
Faraday::Response::ParseJson is deprecated.

### DIFF
--- a/lib/mtgox/connection.rb
+++ b/lib/mtgox/connection.rb
@@ -1,7 +1,6 @@
 require 'faraday'
 require 'faraday/request/url_encoded'
 require 'faraday/response/raise_error'
-require 'faraday/response/parse_json'
 require 'faraday/response/raise_mtgox_error'
 require 'faraday_middleware'
 require 'mtgox/version'
@@ -23,7 +22,7 @@ module MtGox
       Faraday.new(options) do |connection|
         connection.use Faraday::Request::UrlEncoded
         connection.use Faraday::Response::RaiseError
-        connection.use Faraday::Response::ParseJson
+        connection.use FaradayMiddleware::ParseJson
         connection.use Faraday::Response::RaiseMtGoxError
         connection.adapter(Faraday.default_adapter)
       end


### PR DESCRIPTION
And "faraday/response/parse_json" does not exist anymore.
