### PR TITLE
Add BTC executable to pull current BTC->USD rate. Update README accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ Then, install the gem with the high security trust policy:
 
     gem install mtgox -P HighSecurity
 
-## Alias
+## Executable
 After installing the gem, you can get the current price for 1 BTC in USD by
-typing `btc` in your bash shell simply by setting the following alias:
+typing `btc` in your bash shell:
 
-    alias btc='ruby -r rubygems -r mtgox -e "puts MtGox.ticker.sell"'
+    $ btc
+    50.00
+
 
 ## Documentation
 [http://rdoc.info/gems/mtgox][documentation]

--- a/bin/btc
+++ b/bin/btc
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'mtgox'
+
+puts MtGox.ticker.sell

--- a/mtgox.gemspec
+++ b/mtgox.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
   spec.cert_chain  = ['certs/sferik.pem']
   spec.description = %q{Ruby wrapper for the Mt. Gox Trade API. Mt. Gox allows you to trade US Dollars (USD) for Bitcoins (BTC) or Bitcoins for US Dollars.}
   spec.email       = 'sferik@gmail.com'
+  spec.executable  = 'btc'
   spec.files       = `git ls-files`.split("\n")
   spec.files       = %w(.yardopts CONTRIBUTING.md LICENSE.md README.md Rakefile mtgox.gemspec)
   spec.files      += Dir.glob("lib/**/*.rb")

--- a/mtgox.gemspec
+++ b/mtgox.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.author      = "Erik Michaels-Ober"
+  spec.bindir      = 'bin'
   spec.cert_chain  = ['certs/sferik.pem']
   spec.description = %q{Ruby wrapper for the Mt. Gox Trade API. Mt. Gox allows you to trade US Dollars (USD) for Bitcoins (BTC) or Bitcoins for US Dollars.}
   spec.email       = 'sferik@gmail.com'


### PR DESCRIPTION
I'm curious if a executable was _intentionally_ left out of the gem – the alias function seems pretty dense when, if you're like me, you're really just looking for a quick way to check the exchange rate. 

Let me know if you have any changes you want me to make on my fork – I've tested it locally and it works great! I'll probably keep it around on my local machine as a quick tool regardless!
