### PR TITLE
mtgox declines API calls to mtgox.com

### DIFF
--- a/lib/mtgox/connection.rb
+++ b/lib/mtgox/connection.rb
@@ -15,7 +15,7 @@ module MtGox
           accept: 'application/json',
           user_agent: "mtgox gem #{MtGox::Version}",
         },
-        url: 'https://mtgox.com',
+        url: 'https://data.mtgox.com',
       }
 
       Faraday.new(options) do |connection|

--- a/lib/mtgox/connection.rb
+++ b/lib/mtgox/connection.rb
@@ -9,13 +9,23 @@ module MtGox
   module Connection
     private
 
-    def connection
+    def connection(method)
       options = {
-        headers:  {
-          accept: 'application/json',
-          user_agent: "mtgox gem #{MtGox::Version}",
-        },
-        url: 'https://data.mtgox.com',
+          headers: {
+              accept: 'application/json',
+              user_agent: "mtgox gem #{MtGox::Version}",
+          },
+          # data.mtgox.com is needed for the unauthenticated calls
+          # It works with authenticated calls, but that is not what is recommended per
+          # https://bitcointalk.org/index.php?topic=150786.0
+          # mtgox.com should probably be used for authenticated calls
+          url:
+              case method
+                when :get
+                  'https://data.mtgox.com'
+                when :post
+                  'https://mtgox.com'
+              end
       }
 
       Faraday.new(options) do |connection|

--- a/lib/mtgox/request.rb
+++ b/lib/mtgox/request.rb
@@ -13,7 +13,10 @@ module MtGox
     private
 
     def request(method, path, options)
-      response = connection.send(method) do |request|
+      # It is from here that the "method" param might distinguish authenticated or not
+      # path certainly does
+      # And you need a different "connection" depending on which.
+      response = connection(method).send(method) do |request|
         case method
         when :get
           request.url(path, options)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -15,19 +15,19 @@ require 'webmock/rspec'
 WebMock.disable_net_connect!(:allow => 'coveralls.io')
 
 def a_get(path)
-  a_request(:get, 'https://mtgox.com' + path)
+  a_request(:get, 'https://data.mtgox.com' + path)
 end
 
 def stub_get(path)
-  stub_request(:get, 'https://mtgox.com' + path)
+  stub_request(:get, 'https://data.mtgox.com' + path)
 end
 
 def a_post(path)
-  a_request(:post, 'https://mtgox.com' + path)
+  a_request(:post, 'https://data.mtgox.com' + path)
 end
 
 def stub_post(path)
-  stub_request(:post, 'https://mtgox.com' + path)
+  stub_request(:post, 'https://data.mtgox.com' + path)
 end
 
 def fixture_path


### PR DESCRIPTION
this replaces use of mtgox.com with data.mtgox.com
