### PR TITLE
Add lag call

### DIFF
--- a/lib/mtgox/client.rb
+++ b/lib/mtgox/client.rb
@@ -11,6 +11,7 @@ require 'mtgox/sell'
 require 'mtgox/ticker'
 require 'mtgox/trade'
 require 'mtgox/value'
+require 'mtgox/lag'
 
 module MtGox
   class Client
@@ -55,6 +56,17 @@ module MtGox
       Ticker.instance.vwap   = value_currency ticker['vwap']
       Ticker.instance.avg   = value_currency ticker['avg']
       Ticker.instance
+    end
+
+    # Fetch the latest lag data
+    #
+    # @authenticated false
+    # @return [MtGox::Lag]
+    # @example
+    #   MtGox.lag
+    def lag
+      lag = get('/api/1/generic/order/lag')
+      Lag.new(lag['lag'], lag['lag_secs'], lag['lag_text'], lag['length'])
     end
 
     # Fetch both bids and asks in one call, for network efficiency

--- a/lib/mtgox/lag.rb
+++ b/lib/mtgox/lag.rb
@@ -1,0 +1,12 @@
+module MtGox
+  class Lag
+    attr_accessor :microseconds, :seconds, :text, :length
+
+    def initialize(lag=nil, lag_secs=nil, lag_text=nil, length=nil)
+      self.microseconds = lag.to_i
+      self.seconds = lag_secs.to_f
+      self.text = lag_text
+      self.length = length.to_i
+    end
+  end
+end

--- a/spec/fixtures/lag.json
+++ b/spec/fixtures/lag.json
@@ -1,0 +1,1 @@
+{"result":"success","return":{"lag":535998,"lag_secs":0.535998,"lag_text":"0.535998 seconds","length":"3"}}

--- a/spec/mtgox/client_spec.rb
+++ b/spec/mtgox/client_spec.rb
@@ -69,6 +69,23 @@ describe MtGox::Client do
     end
   end
 
+  describe '#lag' do
+    before do
+      stub_get('/api/1/generic/order/lag').
+        to_return(status:200, body: fixture('lag.json'))
+    end
+
+    it "should fetch the lag" do
+      lag = @client.lag
+      a_get('/api/1/generic/order/lag').
+        should have_been_made
+      lag.microseconds.should == 535998
+      lag.seconds.should == 0.535998
+      lag.text.should == "0.535998 seconds"
+      lag.length.should == 3
+    end
+  end
+
   describe 'depth methods' do
     before :each do
       stub_get('/api/1/BTCUSD/depth/fetch').


### PR DESCRIPTION
MtGox API [docs](https://en.bitcoin.it/wiki/MtGox/API/HTTP/v1#Order_lag) don't specify what 'length' in the lag response is. I believe it's the number of orders currently queued for execution. 
