### PR TITLE
Implement market order functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ typing `btc` in your bash shell:
     # Place a limit order to sell one bitcoin for $100
     MtGox.sell! 1.0, 100.0
 
+    # Place a market order to sell one bitcoin
+    MtGox.sell! 1.0, :market
+
     # Cancel order #1234567890
     MtGox.cancel 1234567890
 

--- a/lib/mtgox/client.rb
+++ b/lib/mtgox/client.rb
@@ -192,7 +192,7 @@ module MtGox
     #
     # @authenticated true
     # @param amount [Numeric] the number of bitcoins to purchase
-    # @param price [Numeric] the bid price in US dollars
+    # @param price [Numeric or Symbol] the bid price in US dollars, or :market if placing a market order
     # @return [String] order ID for the buy, can be inspected using order_result
     # @example
     #   # Buy one bitcoin for $0.011
@@ -205,7 +205,7 @@ module MtGox
     #
     # @authenticated true
     # @param amount [Numeric] the number of bitcoins to sell
-    # @param price [Numeric] the ask price in US dollars
+    # @param price [Numeric or Symbol] the ask price in US dollars, or :market if placing a market order
     # @return [String] order ID for the sell, can be inspected using order_result
     # @example
     #   # Sell one bitcoin for $100
@@ -219,13 +219,17 @@ module MtGox
     # @authenticated true
     # @param type [String] the type of order to create, either "buy" or "sell"
     # @param amount [Numberic] the number of bitcoins to buy/sell
-    # @param price [Numeric] the bid/ask price in USD
+    # @param price [Numeric or Symbol] the bid/ask price in USD, or :market if placing a market order
     # @return [String] order ID for the order, can be inspected using order_result
     # @example
     #   # Sell one bitcoin for $123
     #   MtGox.addorder! :sell, 1.0, 123.0
     def addorder!(type, amount, price)
-      post('/api/1/BTCUSD/order/add', {type: order_type(type), amount_int: intify(amount,:btc), price_int: intify(price, :usd)})
+      order = {type: order_type(type), amount_int: intify(amount,:btc)}
+      if price != :market
+          order[:price_int] = intify(price, :usd)
+      end
+      post('/api/1/BTCUSD/order/add', order)
     end
 
     # Cancel an open order

--- a/spec/mtgox/client_spec.rb
+++ b/spec/mtgox/client_spec.rb
@@ -245,8 +245,13 @@ describe MtGox::Client do
   describe "#buy!" do
     before do
       body = test_body({"type" => "bid", "amount_int" => "88000000", "price_int" => "89000"})
+      body_market = test_body({"type" => "bid", "amount_int" => "88000000"})
+
       stub_post('/api/1/BTCUSD/order/add').
         with(body: body, headers: test_headers(body)).
+        to_return(status: 200, body: fixture('buy.json'))
+      stub_post('/api/1/BTCUSD/order/add').
+        with(body: body_market, headers: test_headers(body_market)).
         to_return(status: 200, body: fixture('buy.json'))
     end
 
@@ -258,13 +263,27 @@ describe MtGox::Client do
         should have_been_made
       buy.should == "490a214f-9a30-449f-acb8-780f9046502f"
     end
+
+    it "should place a market bid" do
+      buy = @client.buy!(0.88, :market)
+      body_market = test_body({"type" => "bid", "amount_int" => "88000000"})
+      a_post("/api/1/BTCUSD/order/add").
+        with(body: body_market, headers: test_headers(body_market)).
+        should have_been_made
+      buy.should == "490a214f-9a30-449f-acb8-780f9046502f"
+    end
   end
 
   describe "#sell!" do
     before do
       body = test_body({"type" => "ask", "amount_int" => "88000000", "price_int" => "8900000"})
+      body_market = test_body({"type" => "ask", "amount_int" => "88000000"})
+
       stub_post('/api/1/BTCUSD/order/add').
         with(body: body, headers: test_headers(body)).
+        to_return(status: 200, body: fixture('sell.json'))
+      stub_post('/api/1/BTCUSD/order/add').
+        with(body: body_market, headers: test_headers(body_market)).
         to_return(status: 200, body: fixture('sell.json'))
     end
 
@@ -273,6 +292,15 @@ describe MtGox::Client do
       sell = @client.sell!(0.88, 89.0)
       a_post("/api/1/BTCUSD/order/add").
         with(body: body, headers: test_headers(body)).
+        should have_been_made
+      sell.should == "a20329fe-c0d5-4378-b204-79a7800d41e7"
+    end
+
+    it "should place a market ask" do
+      body_market = test_body({"type" => "ask", "amount_int" => "88000000"})
+      sell = @client.sell!(0.88, :market)
+      a_post("/api/1/BTCUSD/order/add").
+        with(body: body_market, headers: test_headers(body_market)).
         should have_been_made
       sell.should == "a20329fe-c0d5-4378-b204-79a7800d41e7"
     end


### PR DESCRIPTION
Users can place market orders like so:

``` ruby
MtGox.buy! 100, :market

MtGox.sell! 100, :market
```

Tested on MtGox.
