### PR TITLE
Support per-user clients

### DIFF
--- a/lib/mtgox.rb
+++ b/lib/mtgox.rb
@@ -1,15 +1,13 @@
 require 'mtgox/client'
-require 'mtgox/configuration'
 require 'mtgox/error'
 
 module MtGox
-  extend Configuration
   class << self
     # Alias for MtGox::Client.new
     #
     # @return [MtGox::Client]
     def new
-      MtGox::Client.new
+      @client ||= MtGox::Client.new
     end
 
     # Delegate to MtGox::Client

--- a/lib/mtgox/ask.rb
+++ b/lib/mtgox/ask.rb
@@ -5,7 +5,8 @@ module MtGox
   class Ask < Offer
     include MtGox::Value
 
-    def initialize(hash = nil)
+    def initialize(client, hash = nil)
+      self.client = client
       if hash
         self.price = value_currency hash, 'price_int'
         self.amount = value_bitcoin hash, 'amount_int'
@@ -14,7 +15,7 @@ module MtGox
     end
 
     def eprice
-      price / (1 - MtGox.commission)
+      price / (1 - self.client.commission)
     end
 
   end

--- a/lib/mtgox/bid.rb
+++ b/lib/mtgox/bid.rb
@@ -5,7 +5,8 @@ module MtGox
   class Bid < Offer
     include MtGox::Value
 
-    def initialize(hash = nil)
+    def initialize(client, hash = nil)
+      self.client = client
       if hash
         self.price = value_currency hash, 'price_int'
         self.amount = value_bitcoin hash, 'amount_int'
@@ -14,7 +15,7 @@ module MtGox
     end
 
     def eprice
-      price * (1 - MtGox.commission)
+      price * (1 - self.client.commission)
     end
 
   end

--- a/lib/mtgox/min_ask.rb
+++ b/lib/mtgox/min_ask.rb
@@ -1,10 +1,8 @@
 require 'mtgox/ask'
 require 'mtgox/price_ticker'
-require 'singleton'
 
 module MtGox
   class MinAsk < Ask
-    include Singleton
     include PriceTicker
   end
 end

--- a/lib/mtgox/offer.rb
+++ b/lib/mtgox/offer.rb
@@ -1,5 +1,5 @@
 module MtGox
   class Offer
-    attr_accessor :amount, :price, :timestamp
+    attr_accessor :amount, :price, :timestamp, :client
   end
 end

--- a/lib/mtgox/request.rb
+++ b/lib/mtgox/request.rb
@@ -33,10 +33,10 @@ module MtGox
     def headers(request)
       signature = Base64.strict_encode64(
         OpenSSL::HMAC.digest 'sha512',
-        Base64.decode64(MtGox.secret),
+        Base64.decode64(secret),
         request
       )
-      {'Rest-Key' => MtGox.key, 'Rest-Sign' => signature}
+      {'Rest-Key' => key, 'Rest-Sign' => signature}
     end
 
     def body_from_options(options)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -47,13 +47,13 @@ module MtGox
   end
 end
 
-def test_headers(body=test_body)
+def test_headers(client, body=test_body)
   signature = Base64.strict_encode64(
     OpenSSL::HMAC.digest 'sha512',
-    Base64.decode64(MtGox.secret),
+    Base64.decode64(client.secret),
     body
   )
-  {'Rest-Key' => MtGox.key, 'Rest-Sign' => signature}
+  {'Rest-Key' => client.key, 'Rest-Sign' => signature}
 end
 
 def test_body(options={})


### PR DESCRIPTION
This makes MtGox usable as a non-singleton by calling client =
MtGox::Client.new.  The older, singleton-esque api still works by
building a client and storing it as a class instance variable on MtGox,
if that's desired.

This closes #37
