### PR TITLE
Remove seemingly unused options hash.

### DIFF
--- a/lib/mtgox/configuration.rb
+++ b/lib/mtgox/configuration.rb
@@ -23,13 +23,6 @@ module MtGox
       yield self
     end
 
-    # Create a hash of options and their values
-    def options
-      options = {}
-      VALID_OPTIONS_KEYS.each{|k| options[k] = send(k)}
-      options
-    end
-
     # Reset all configuration options to defaults
     def reset
       self.commission = DEFAULT_COMMISSION


### PR DESCRIPTION
Nothing changes except code coverage increases. Either this code is never, ever used or it's mocked so well that we never see whether it's actually being used. :wink: 
