### PR TITLE
Fetch more details from the orders api

### DIFF
--- a/lib/mtgox.rb
+++ b/lib/mtgox.rb
@@ -1,3 +1,4 @@
+require 'bigdecimal'
 require 'mtgox/client'
 require 'mtgox/error'
 

--- a/lib/mtgox.rb
+++ b/lib/mtgox.rb
@@ -1,4 +1,3 @@
-require 'bigdecimal'
 require 'mtgox/client'
 require 'mtgox/error'
 

--- a/lib/mtgox/balance.rb
+++ b/lib/mtgox/balance.rb
@@ -4,7 +4,7 @@ module MtGox
 
     def initialize(currency=nil, amount=nil)
       self.currency = currency.to_s.upcase
-      self.amount = BigDecimal(amount)
+      self.amount = BigDecimal(amount.to_s)
     end
   end
 end

--- a/lib/mtgox/balance.rb
+++ b/lib/mtgox/balance.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 module MtGox
   class Balance
     attr_accessor :currency, :amount

--- a/lib/mtgox/balance.rb
+++ b/lib/mtgox/balance.rb
@@ -4,7 +4,7 @@ module MtGox
 
     def initialize(currency=nil, amount=nil)
       self.currency = currency.to_s.upcase
-      self.amount = amount.to_f
+      self.amount = BigDecimal(amount)
     end
   end
 end

--- a/lib/mtgox/configuration.rb
+++ b/lib/mtgox/configuration.rb
@@ -1,4 +1,5 @@
 require 'mtgox/version'
+require 'bigdecimal'
 
 module MtGox
   module Configuration

--- a/lib/mtgox/configuration.rb
+++ b/lib/mtgox/configuration.rb
@@ -9,7 +9,7 @@ module MtGox
       :secret,
     ]
 
-    DEFAULT_COMMISSION = 0.0065.freeze
+    DEFAULT_COMMISSION = BigDecimal('0.0065').freeze
 
     attr_accessor *VALID_OPTIONS_KEYS
 

--- a/lib/mtgox/lag.rb
+++ b/lib/mtgox/lag.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 module MtGox
   class Lag
     attr_accessor :microseconds, :seconds, :text, :length

--- a/lib/mtgox/lag.rb
+++ b/lib/mtgox/lag.rb
@@ -4,7 +4,7 @@ module MtGox
 
     def initialize(lag=nil, lag_secs=nil, lag_text=nil, length=nil)
       self.microseconds = lag.to_i
-      self.seconds = lag_secs.to_f
+      self.seconds = BigDecimal(lag_secs.to_s)
       self.text = lag_text
       self.length = length.to_i
     end

--- a/lib/mtgox/order.rb
+++ b/lib/mtgox/order.rb
@@ -1,4 +1,5 @@
 require 'mtgox/offer'
+require 'bigdecimal'
 
 module MtGox
   class Order < Offer

--- a/lib/mtgox/order.rb
+++ b/lib/mtgox/order.rb
@@ -1,14 +1,18 @@
 require 'mtgox/offer'
+require 'bigdecimal'
 
 module MtGox
   class Order < Offer
-    attr_accessor :id, :date
+    attr_accessor :id, :date, :item, :status, :currency
 
     def initialize(order={})
       self.id     = order['oid']
       self.date   = Time.at(order['date'].to_i)
-      self.amount = order['amount']['value'].to_f
-      self.price  = order['price']['value'].to_f
+      self.amount = BigDecimal(order['amount']['value'])
+      self.price  = BigDecimal(order['price']['value'])
+      self.item   = order['item']
+      self.status = order['status']
+      self.currency = order['currency']
     end
   end
 end

--- a/lib/mtgox/order.rb
+++ b/lib/mtgox/order.rb
@@ -1,5 +1,4 @@
 require 'mtgox/offer'
-require 'bigdecimal'
 
 module MtGox
   class Order < Offer

--- a/lib/mtgox/price_ticker.rb
+++ b/lib/mtgox/price_ticker.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 module MtGox
   module PriceTicker
     attr_reader :previous_price, :price

--- a/lib/mtgox/price_ticker.rb
+++ b/lib/mtgox/price_ticker.rb
@@ -8,15 +8,15 @@ module MtGox
     end
 
     def up?
-      price.to_f > previous_price.to_f
+      BigDecimal(price) > BigDecimal(previous_price)
     end
 
     def down?
-      price.to_f < previous_price.to_f
+      BigDecimal(price) < BigDecimal(previous_price)
     end
 
     def changed?
-      price.to_f != previous_price.to_f
+      BigDecimal(price) != BigDecimal(previous_price)
     end
 
     def unchanged?

--- a/lib/mtgox/price_ticker.rb
+++ b/lib/mtgox/price_ticker.rb
@@ -8,15 +8,15 @@ module MtGox
     end
 
     def up?
-      BigDecimal(price) > BigDecimal(previous_price)
+      BigDecimal(price.to_s) > BigDecimal(previous_price.to_s)
     end
 
     def down?
-      BigDecimal(price) < BigDecimal(previous_price)
+      BigDecimal(price.to_s) < BigDecimal(previous_price.to_s)
     end
 
     def changed?
-      BigDecimal(price) != BigDecimal(previous_price)
+      BigDecimal(price.to_s) != BigDecimal(previous_price.to_s)
     end
 
     def unchanged?

--- a/lib/mtgox/trade.rb
+++ b/lib/mtgox/trade.rb
@@ -6,8 +6,8 @@ module MtGox
     def initialize(trade={})
       self.id     = trade['tid'].to_i
       self.date   = Time.at(trade['date'].to_i)
-      self.amount = trade['amount'].to_f
-      self.price  = trade['price'].to_f
+      self.amount = BigDecimal(trade['amount'])
+      self.price  = BigDecimal(trade['price'])
     end
   end
 end

--- a/lib/mtgox/value.rb
+++ b/lib/mtgox/value.rb
@@ -18,7 +18,7 @@ module MtGox
     # @authenticated false
     # @return [Float]
     def value_currency(value, key = 'value_int')
-      floatify(value[key].to_i, :usd)
+      decimalify(value[key].to_i, :usd)
     end
 
     # Takes a hash return by the API and convert some value_int to
@@ -29,25 +29,25 @@ module MtGox
     # @authenticated false
     # @return [Float] a float BTC value
     def value_bitcoin(value, key = 'value_int')
-      floatify(value[key], :btc)
+      decimalify(value[key], :btc)
     end
 
-    # Convert a float value to an int using the MtGox conversion rules.
+    # Convert a BigDecimal value to an int using the MtGox conversion rules.
     #
-    # param float [Float] to convert
+    # param decimal [BigDecimal] to convert
     # param currency [Symbol] currency conversion rule to use amongst [:btc, :usd, :jpy]
     # return an int
-    def intify(float, currency)
-      (float * INT_MULTIPLIERS[currency]).to_i
+    def intify(decimal, currency)
+      (decimal * INT_MULTIPLIERS[currency]).to_i
     end
 
-    # Convert an int value to a float using the MtGox conversion rules.
+    # Convert an int value to a decimal using the MtGox conversion rules.
     #
     # param int [Fixnum] to convert
     # param currency [Symbol] currency conversion rule to use amongst [:btc, :usd, :jpy]
-    # return a [Float]
-    def floatify(int, currency)
-      (int.to_f / INT_MULTIPLIERS[currency])
+    # return a [BigDecimal]
+    def decimalify(int, currency)
+      (BigDecimal(int) / INT_MULTIPLIERS[currency])
     end
   end
 end

--- a/lib/mtgox/value.rb
+++ b/lib/mtgox/value.rb
@@ -47,7 +47,7 @@ module MtGox
     # param currency [Symbol] currency conversion rule to use amongst [:btc, :usd, :jpy]
     # return a [BigDecimal]
     def decimalify(int, currency)
-      (BigDecimal(int) / INT_MULTIPLIERS[currency])
+      (BigDecimal(int.to_s) / INT_MULTIPLIERS[currency])
     end
   end
 end

--- a/lib/mtgox/value.rb
+++ b/lib/mtgox/value.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 # In the "old API", currency- and amount-values (price, volume,...)
 # were given as float. These values are likely being deprecated and
 # replaced by fields of the same name with "_int" as suffix. These are

--- a/spec/mtgox/client_spec.rb
+++ b/spec/mtgox/client_spec.rb
@@ -47,14 +47,14 @@ describe MtGox::Client do
       ticker = @client.ticker
       a_get('/api/1/BTCUSD/ticker').
         should have_been_made
-      ticker.buy.should  == 5.53587
-      ticker.sell.should == 5.56031
-      ticker.high.should == 5.70653
-      ticker.low.should == 5.4145
-      ticker.price.should == 5.5594
-      ticker.volume.should  == 55829.58960346
-      ticker.vwap.should == 5.61048
-      ticker.avg.should == 5.56112
+      ticker.buy.should  == BigDecimal('5.53587')
+      ticker.sell.should == BigDecimal('5.56031')
+      ticker.high.should == BigDecimal('5.70653')
+      ticker.low.should == BigDecimal('5.4145')
+      ticker.price.should == BigDecimal('5.5594')
+      ticker.volume.should  == BigDecimal('55829.58960346')
+      ticker.vwap.should == BigDecimal('5.61048')
+      ticker.avg.should == BigDecimal('5.56112')
     end
 
     it "should fetch the ticker and keep previous price" do
@@ -80,7 +80,7 @@ describe MtGox::Client do
       a_get('/api/1/generic/order/lag').
         should have_been_made
       lag.microseconds.should == 535998
-      lag.seconds.should == 0.535998
+      lag.seconds.should == BigDecimal('0.535998')
       lag.text.should == "0.535998 seconds"
       lag.length.should == 3
     end
@@ -98,8 +98,8 @@ describe MtGox::Client do
         a_get('/api/1/BTCUSD/depth/fetch').
           should have_been_made
         asks.first.price.should == 114
-        asks.first.eprice.should == 114.74584801207851
-        asks.first.amount.should == 0.43936758
+        asks.first.eprice.should == BigDecimal('114.745848012')
+        asks.first.amount.should == BigDecimal('0.43936758')
       end
 
       it "should be sorted in price-ascending order" do
@@ -114,9 +114,9 @@ describe MtGox::Client do
         bids = @client.bids
         a_get('/api/1/BTCUSD/depth/fetch').
           should have_been_made
-        bids.first.price.should == 113.0
-        bids.first.eprice.should == 112.2655
-        bids.first.amount.should == 124.69802063
+        bids.first.price.should == BigDecimal('113.0')
+        bids.first.eprice.should == BigDecimal('112.2655')
+        bids.first.amount.should == BigDecimal('124.69802063')
       end
 
       it "should be sorted in price-descending order" do
@@ -131,11 +131,11 @@ describe MtGox::Client do
         a_get('/api/1/BTCUSD/depth/fetch').
           should have_been_made.once
         offers[:asks].first.price.should == 114
-        offers[:asks].first.eprice.should == 114.74584801207851
-        offers[:asks].first.amount.should == 0.43936758
-        offers[:bids].first.price.should == 113.0
-        offers[:bids].first.eprice.should == 112.2655
-        offers[:bids].first.amount.should == 124.69802063
+        offers[:asks].first.eprice.should == BigDecimal('114.745848012')
+        offers[:asks].first.amount.should == BigDecimal('0.43936758')
+        offers[:bids].first.price.should == BigDecimal('113.0')
+        offers[:bids].first.eprice.should == BigDecimal('112.2655')
+        offers[:bids].first.amount.should == BigDecimal('124.69802063')
       end
     end
 
@@ -145,8 +145,8 @@ describe MtGox::Client do
         a_get('/api/1/BTCUSD/depth/fetch').
           should have_been_made.once
         min_ask.price.should == 114
-        min_ask.eprice.should == 114.74584801207851
-        min_ask.amount.should == 0.43936758
+        min_ask.eprice.should == BigDecimal('114.745848012')
+        min_ask.amount.should == BigDecimal('0.43936758')
       end
     end
 
@@ -156,8 +156,8 @@ describe MtGox::Client do
         a_get('/api/1/BTCUSD/depth/fetch').
           should have_been_made.once
         max_bid.price.should == 113
-        max_bid.eprice.should == 112.2655
-        max_bid.amount.should == 124.69802063
+        max_bid.eprice.should == BigDecimal('112.2655')
+        max_bid.amount.should == BigDecimal('124.69802063')
       end
     end
 
@@ -174,8 +174,8 @@ describe MtGox::Client do
       a_get('/api/1/BTCUSD/trades/fetch').
         should have_been_made
       trades.last.date.should == Time.utc(2013, 4, 12, 15, 20, 3)
-      trades.last.price.should == 73.19258
-      trades.last.amount.should == 0.94043572
+      trades.last.price.should == BigDecimal('73.19258')
+      trades.last.amount.should == BigDecimal('0.94043572')
       trades.last.id.should == 1365780003374123
     end
   end
@@ -192,8 +192,8 @@ describe MtGox::Client do
       #puts trades.inspect
       a_get('/api/1/BTCUSD/trades/fetch?since=1365780002144150').
         should have_been_made
-      trades.first.price.should == 72.98274
-      trades.first.amount.should == 11.76583944
+      trades.first.price.should == BigDecimal('72.98274')
+      trades.first.amount.should == BigDecimal('11.76583944')
       trades.first.id.should == 1365780002144150
     end
   end
@@ -211,9 +211,9 @@ describe MtGox::Client do
         with(body: test_body, headers: test_headers(@client)).
         should have_been_made
       balance.first.currency.should == "BTC"
-      balance.first.amount.should == 42.0
+      balance.first.amount.should == BigDecimal('42.0')
       balance.last.currency.should == "EUR"
-      balance.last.amount.should == 23.0
+      balance.last.amount.should == BigDecimal('23.0')
     end
   end
 
@@ -245,7 +245,7 @@ describe MtGox::Client do
         a_post("/api/1/generic/orders").
           with(body: test_body, headers: test_headers(@client)).
           should have_been_made
-        sells.last.price.should == 99.0
+        sells.last.price.should == BigDecimal('99.0')
         sells.last.date.should == Time.utc(2011, 6, 27, 18, 20, 20)
       end
     end
@@ -256,9 +256,9 @@ describe MtGox::Client do
         a_post("/api/1/generic/orders").
           with(body: test_body, headers: test_headers(@client)).
           should have_been_made
-        orders[:buys].last.price.should == 7.0
+        orders[:buys].last.price.should == BigDecimal('7.0')
         orders[:buys].last.date.should == Time.utc(2011, 6, 27, 18, 20, 38)
-        orders[:sells].last.price.should == 99.0
+        orders[:sells].last.price.should == BigDecimal('99.0')
         orders[:sells].last.date.should == Time.utc(2011, 6, 27, 18, 20, 20)
       end
     end
@@ -367,7 +367,7 @@ describe MtGox::Client do
           with(body: body, headers: test_headers(@client, body)).
           should have_been_made
         cancel[:buys].length.should == 0
-        cancel[:sells].last.price.should == 99.0
+        cancel[:sells].last.price.should == BigDecimal('99.0')
         cancel[:sells].last.date.should == Time.utc(2011, 6, 27, 18, 20, 20)
       end
     end

--- a/spec/mtgox/client_spec.rb
+++ b/spec/mtgox/client_spec.rb
@@ -232,6 +232,10 @@ describe MtGox::Client do
           should have_been_made
         buys.last.price.should == 7
         buys.last.date.should == Time.utc(2011, 6, 27, 18, 20, 38)
+        buys.last.amount.should == BigDecimal("0.2")
+        buys.last.status.should == "open"
+        buys.last.currency.should == "USD"
+        buys.last.item.should == "BTC"
       end
     end
 


### PR DESCRIPTION
There were some Mt. Gox Order Details that weren't being fetched into
the local MtGox::Order object.  This change fetches those and makes them
accessible, as well as preferring BigDecimal to Float.

What are your thoughts on these changes @sferik?  I was mildly concerned when I saw floats being used, and so that was an unexpected change I introduced.  The other is really just proxying data through that they provide that we weren't providing.
