### PR TITLE
Add MtGox::OrderNotFoundError

### DIFF
--- a/lib/mtgox/client.rb
+++ b/lib/mtgox/client.rb
@@ -267,7 +267,7 @@ module MtGox
         orders.delete_if{|o| o['oid'] == res['oid']}
         parse_orders(orders)
       else
-        raise Faraday::Error::ResourceNotFound, {status: 404, headers: {}, body: 'Order not found.'}
+        raise MtGox::OrderNotFoundError
       end
     end
     alias cancel_order cancel

--- a/lib/mtgox/error.rb
+++ b/lib/mtgox/error.rb
@@ -4,5 +4,6 @@ module MtGox
   class MysqlError < Error; end
   class UnauthorizedError < Error; end
   class FilthyRichError < Error; end
+  class OrderNotFoundError < Error; end
 end
 

--- a/spec/mtgox/client_spec.rb
+++ b/spec/mtgox/client_spec.rb
@@ -351,7 +351,7 @@ describe MtGox::Client do
 
     context "with an invalid oid passed" do
       it "should raise an error" do
-        expect { @client.cancel(1234567890) }.to raise_error(Faraday::Error::ResourceNotFound)
+        expect { @client.cancel(1234567890) }.to raise_error(MtGox::OrderNotFoundError)
       end
     end
 


### PR DESCRIPTION
This way we don't raise errors from different layers of the stack.  Fixes #43
