### PR TITLE
Add nonce_type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ MtGox.cancel 1234567890
 
 # Withdraw 1 BTC from your account
 MtGox.withdraw! 1.0, "1KxSo9bGBfPVFEtWNLpnUK1bfLNNT4q31L"
+
+# Switch to sending 'tonce' rather than 'nonce'
+MtGox.nonce_type = :tonce
 ```
 
 ## Contributing

--- a/lib/mtgox/configuration.rb
+++ b/lib/mtgox/configuration.rb
@@ -8,9 +8,11 @@ module MtGox
       :commission,
       :key,
       :secret,
+      :nonce_type
     ]
 
     DEFAULT_COMMISSION = BigDecimal('0.0065').freeze
+    DEFAULT_NONCE_TYPE = :nonce
 
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -27,9 +29,13 @@ module MtGox
     # Reset all configuration options to defaults
     def reset
       self.commission = DEFAULT_COMMISSION
-      self.key   = nil
-      self.secret   = nil
+      self.key = nil
+      self.secret = nil
       self
+    end
+
+    def nonce_type
+      @nonce_type || DEFAULT_NONCE_TYPE
     end
   end
 end

--- a/lib/mtgox/request.rb
+++ b/lib/mtgox/request.rb
@@ -44,7 +44,7 @@ module MtGox
     end
 
     def add_nonce(options)
-      options.merge!({nonce: (Time.now.to_f * 1000000).to_i})
+      options.merge!({self.nonce_type => (Time.now.to_f * 1000000).to_i})
     end
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -49,7 +49,7 @@ module MtGox
   module Request
   private
     def add_nonce(options)
-      options.merge!({nonce: 1321745961249676})
+      options.merge!({self.nonce_type => 1321745961249676})
     end
   end
 end

--- a/spec/mtgox/client_spec.rb
+++ b/spec/mtgox/client_spec.rb
@@ -358,4 +358,21 @@ describe MtGox::Client do
       }.to raise_error(MtGox::FilthyRichError)
     end
   end
+
+  describe "nonce_type" do
+    before do
+      stub_post('/api/1/generic/bitcoin/address').
+        to_return(body: fixture('address.json'))
+    end
+
+    it "uses nonce by default" do
+      address = @client.address
+      expect(a_post('/api/1/generic/bitcoin/address').with(nonce: 1321745961249676)).to have_been_made
+    end
+
+    it "is capable of using tonce" do
+      address = @client.address
+      expect(a_post('/api/1/generic/bitcoin/address').with(tonce: 1321745961249676)).to have_been_made
+    end
+  end
 end

--- a/spec/mtgox_spec.rb
+++ b/spec/mtgox_spec.rb
@@ -17,6 +17,14 @@ describe MtGox do
       expect(MtGox.key).to eq "key"
       expect(MtGox.secret).to eq "secret"
     end
+
+    it "allows setting nonce type" do
+      expect(MtGox.nonce_type).to eq(:nonce)
+      MtGox.configure do |config|
+        config.nonce_type = :tonce
+      end
+      expect(MtGox.nonce_type).to eq(:tonce)
+    end
   end
 
 end


### PR DESCRIPTION
Allows you to specify that you'd like to use the 'tonce' parameter
rather than 'nonce'.  This is useful for when you have multiple
threads/processes communicating and you can't be sure that a given
request will block before another occurs, etc.

It doesn't change the default behaviour, but you can configure
`client.nonce_type = :tonce` and it will change the parameter sent.

The test added with this to test that the request includes tonce rather
than nonce is not valuable until
https://github.com/bblimke/webmock/issues/297 is fixed.  It's still the
test that should go along with this.
