### PR TITLE
Actually configure test for tonce... :-\

### DIFF
--- a/spec/mtgox/client_spec.rb
+++ b/spec/mtgox/client_spec.rb
@@ -371,6 +371,7 @@ describe MtGox::Client do
     end
 
     it "is capable of using tonce" do
+      @client.nonce_type = :tonce
       address = @client.address
       expect(a_post('/api/1/generic/bitcoin/address').with(tonce: 1321745961249676)).to have_been_made
     end


### PR DESCRIPTION
So I mentioned this test wasn't an appropriate test yet because of a bug
I found in webmock - in testing that bug, I had failed to fix the test
appropriately to actually configure for tonces.  When the webmock bug is
fixed, this would start failing without this commit.  Sorry.
